### PR TITLE
Reject all ssl errors

### DIFF
--- a/src/main/scala/com/fortysevendeg/android/scaladays/ui/social/AuthorizationActivity.scala
+++ b/src/main/scala/com/fortysevendeg/android/scaladays/ui/social/AuthorizationActivity.scala
@@ -65,7 +65,7 @@ class AuthorizationActivity
 
     }
     override def onReceivedSslError(view: WebView, handler: SslErrorHandler, error: SslError) {
-      handler.proceed()
+      handler.cancel()
     }
   }
 


### PR DESCRIPTION
This code is used in the Twitter authorization and the Twitter login page has a valid SSL certificate. In any case, I've tested it and it works flawlessly.

Please, @javipacheco @franciscodr could you review? Thanks